### PR TITLE
Add module dependencies in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,18 @@
   "license": "Apache-2.0",
   "source": "",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 7.0.0 <= 8.5.0"
+    },
+    {
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.1.0 <= 4.0.1"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 4.3.0 <= 6.1.1"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Update `metadata.json` to include module dependencies. Minimum version of stdlib and systemd is based on Puppet version, while for Archive v.4.3.0 has been chosen as it includes initial support for EL8.