### PR TITLE
Cleanup redundant http config options

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -37,11 +37,6 @@ zot::config_file: /etc/zot/config.yaml
 zot::config_hash: ~
 zot::gid: 991
 zot::group: zot
-zot::http_address: 0.0.0.0
-zot::http_auth: {}
-zot::http_port: 5000
-zot::http_realm: zot
-zot::http_tls: {}
 zot::install_method: url
 zot::log_dir: /var/log/zot
 zot::manage_config_dir: true


### PR DESCRIPTION
`data/common.yaml` held some individual `http_*` options that are instead managed with the `zot::config_http` Hash. 